### PR TITLE
Add support to phpUnit 6 and 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,25 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
     - 7.0
+    - 7.1
+    - 7.2
     - hhvm
 
-matrix:
-    allow_failures:
-        - php: 7.0
+env:
+    matrix:
+        - COMPOSER_FLAGS="--prefer-lowest"
+        - COMPOSER_FLAGS=""
 
 sudo: false
 
+cache:
+    directories:
+        - $HOME/.composer/cache
+
 before_script:
-    - composer self-update
-    - composer update
+    - travis_retry composer self-update
+    - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist -vvv
 
 script:
     - php vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
     - 7.0
     - 7.1
     - 7.2
-    - hhvm
 
 env:
     matrix:

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
 		"issues": "https://github.com/tomzx/ditto/issues"
 	},
 	"require": {
-		"php": ">=5.4",
-		"illuminate/container": "~4.2|~5.0"
+		"php": ">=7.0",
+		"illuminate/container": "^5.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~4.1"
+		"phpunit/phpunit": "^6.0|^7.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
 	</filter>
 
 	<logging>
-		<log type="coverage-html" target="./log/report" charset="UTF-8" yui="true" highlight="true" lowUpperBound="50" highLowerBound="80" />
+		<log type="coverage-html" target="./log/report" lowUpperBound="50" highLowerBound="80" />
 		<log type="coverage-text" target="./log/coverage.txt"/>
 		<log type="coverage-clover" target="./log/coverage.xml"/>
 		<log type="testdox-html" target="./log/testdox.html" />

--- a/tests/Ditto/DittoTest.php
+++ b/tests/Ditto/DittoTest.php
@@ -1,33 +1,39 @@
 <?php namespace Ditto\Test;
 
 use Ditto\Ditto as d;
+use Ditto\Ditto;
+use Ditto\Test\Fixtures\Classes\A;
+use Ditto\Test\Fixtures\Classes\B;
+use Ditto\Test\Fixtures\Classes\C;
+use PHPUnit\Framework\TestCase;
+use stdClass;
 
-class DittoTest extends \PHPUnit_Framework_TestCase {
+class DittoTest extends TestCase {
 	public function testItIsInitializable()
 	{
-		$this->assertInstanceOf('Ditto\Ditto', d::make('stdClass'));
+		$this->assertInstanceOf(Ditto::class, d::make(stdClass::class));
 	}
 
 	public function testItCanInstantiateArgumentlessClasses()
 	{
-		$this->assertInstanceOf('Ditto\Ditto', d::make('Ditto\Test\Fixtures\Classes\A'));
+		$this->assertInstanceOf(Ditto::class, d::make(A::class));
 	}
 
 	public function testItCanInstantiateClassesWithArguments()
 	{
-		$ditto = d::make('Ditto\Test\Fixtures\Classes\C');
-		$this->assertInstanceOf('Ditto\Ditto', $ditto);
-		$this->assertInstanceOf('Ditto\Test\Fixtures\Classes\A', $ditto->a);
-		$this->assertInstanceOf('Ditto\Test\Fixtures\Classes\B', $ditto->b);
-		$this->assertInstanceOf('Ditto\Test\Fixtures\Classes\A', $ditto->b->a);
+		$ditto = d::make(C::class);
+		$this->assertInstanceOf(Ditto::class, $ditto);
+		$this->assertInstanceOf(A::class, $ditto->a);
+		$this->assertInstanceOf(B::class, $ditto->b);
+		$this->assertInstanceOf(A::class, $ditto->b->a);
 	}
 
 	public function testItCanSetValuesOnObject()
 	{
-		$ditto = d::make('Ditto\Test\Fixtures\Classes\C');
-		$this->assertInstanceOf('Ditto\Test\Fixtures\Classes\A', $ditto->a);
+		$ditto = d::make(C::class);
+		$this->assertInstanceOf(A::class, $ditto->a);
 		$ditto->a = 'test';
-		$this->assertNotInstanceOf('Ditto\Test\Fixtures\Classes\A', $ditto->a);
+		$this->assertNotInstanceOf(A::class, $ditto->a);
 	}
 
 	public function testItWorksOnIntrinsicValues()
@@ -41,19 +47,19 @@ class DittoTest extends \PHPUnit_Framework_TestCase {
 
 	public function testItTestisXMethodsWhenShouldBeIsCalled()
 	{
-		$ditto = d::make('Ditto\Test\Fixtures\Classes\A');
+		$ditto = d::make(A::class);
 		$ditto->shouldBeAwesome();
 	}
 
 	public function testItTesthasXMethodsWhenShouldHaveIsCalled()
 	{
-		$ditto = d::make('Ditto\Test\Fixtures\Classes\A');
+		$ditto = d::make(A::class);
 		$ditto->shouldHaveJabberwocky();
 	}
 
 	public function testItShouldAssertSame()
 	{
-		$ditto = d::make('Ditto\Test\Fixtures\Classes\A');
+		$ditto = d::make(A::class);
 		$ditto->a()->shouldReturn('a');
 		$ditto->a()->shouldBe('a');
 		$ditto->a()->shouldEqual('a');
@@ -62,14 +68,14 @@ class DittoTest extends \PHPUnit_Framework_TestCase {
 
 	public function testItShouldAssertEquals()
 	{
-		$ditto = d::make('Ditto\Test\Fixtures\Classes\A');
+		$ditto = d::make(A::class);
 		$ditto->a()->shouldBeLike('a');
 	}
 
 	public function testItShouldAssertInstanceOf()
 	{
-		$ditto = d::make('Ditto\Test\Fixtures\Classes\B');
-		$ditto->a()->shouldHaveType('Ditto\Test\Fixtures\Classes\A');
+		$ditto = d::make(B::class);
+		$ditto->a()->shouldHaveType(A::class);
 	}
 
 	public function testItShouldDecapsulateArgumentsIfTheyAreDittoObjects()
@@ -78,8 +84,8 @@ class DittoTest extends \PHPUnit_Framework_TestCase {
 		$ditto_a = d::make($a);
 		$ditto_b = d::make($ditto_a);
 
-		$this->assertInstanceOf('Ditto\Ditto', $ditto_a);
-		$this->assertInstanceOf('Ditto\Ditto', $ditto_b);
+		$this->assertInstanceOf(Ditto::class, $ditto_a);
+		$this->assertInstanceOf(Ditto::class, $ditto_b);
 		$this->assertSame($a, $ditto_a->getObject());
 		$this->assertSame($ditto_a, $ditto_b->getObject());
 		$ditto_a->getThis()->shouldReturn($a);


### PR DESCRIPTION
From phpUnit 6+, we should now use the class `PHPUnit\Framework\Assert` instead of `PHPUnit_Framework_Assert`. The `composer.json` was updated accordingly.

Since this new version of phpUnit is only compatible with PHP 7.0+, I've also updated minimum PHP version and drop the support for Laravel 4.2.

Finally, I've added some phpDoc to make the class more easily usable.